### PR TITLE
Use dummy name for JavaScriptResource.

### DIFF
--- a/src/main/java/org/eclipse/californium/actinium/jscoap/JavaScriptResource.java
+++ b/src/main/java/org/eclipse/californium/actinium/jscoap/JavaScriptResource.java
@@ -36,7 +36,7 @@ public class JavaScriptResource extends LoggerProvidingResource implements JavaS
 	public CoapCallback ondelete = null;
 	
 	public JavaScriptResource() {
-		super(null);
+		super("js-request");
 	}
 
 	public JavaScriptResource(String resourceIdentifier) {


### PR DESCRIPTION
Prevent CoapResource from failing on null names.

Signed-off-by: Achim Kraus <achim.kraus@bosch.io>